### PR TITLE
RF02: Convert double to BigDecimal for accuracy

### DIFF
--- a/src/main/java/com/openpayd/exchange/controller/CurrencyConversionController.java
+++ b/src/main/java/com/openpayd/exchange/controller/CurrencyConversionController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
+
 /**
  * @author suleyman.yildirim
  */
@@ -51,7 +53,7 @@ public class CurrencyConversionController {
             @Parameter(description = "Target currency code", required = true, example = "TRY")
             @RequestParam String targetCurrency,
             @Parameter(description = "Amount to convert", required = true,  example = "15.5")
-            @RequestParam double amount) {
+            @RequestParam BigDecimal amount) {
 
         logger.info("Received request to convert {} {} to {}", amount, sourceCurrency, targetCurrency);
         var conversion = conversionService.convertCurrency(sourceCurrency, targetCurrency, amount);

--- a/src/main/java/com/openpayd/exchange/controller/ExchangeRateController.java
+++ b/src/main/java/com/openpayd/exchange/controller/ExchangeRateController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
+
 /**
  * @author suleyman.yildirim
  */
@@ -47,7 +49,7 @@ public class ExchangeRateController {
                     schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/exchange-rate")
-    public ResponseEntity<Double> getExchangeRate(
+    public ResponseEntity<BigDecimal> getExchangeRate(
             @Parameter(description = "Source currency code. USD is set as a default base currency", required = true, example = "EUR")
             @RequestParam (defaultValue = "USD") String sourceCurrency,
             @Parameter(description = "Target currency code", required = true, example = "GBP")

--- a/src/main/java/com/openpayd/exchange/model/CurrencyConversion.java
+++ b/src/main/java/com/openpayd/exchange/model/CurrencyConversion.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -29,7 +30,7 @@ public class CurrencyConversion {
 
     @PositiveOrZero(message = "convertedAmount must be zero or positive")
     @Schema(name = "The converted amount in the target currency", example = "32.394954")
-    private double convertedAmount;
+    private BigDecimal convertedAmount;
 
     @Schema(name = "The transaction date", example = "2024-07-29")
     private LocalDate createdAt;

--- a/src/main/java/com/openpayd/exchange/service/CurrencyConversionService.java
+++ b/src/main/java/com/openpayd/exchange/service/CurrencyConversionService.java
@@ -14,6 +14,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 
 /**
@@ -39,13 +41,14 @@ public class CurrencyConversionService {
     }
 
     @Transactional
-    public CurrencyConversion convertCurrency(String sourceCurrency, String targetCurrency, double amount) {
+    public CurrencyConversion convertCurrency(String sourceCurrency, String targetCurrency, BigDecimal amount) {
         logger.info("Converting currency from {} to {} for amount {}", sourceCurrency, targetCurrency, amount);
         try {
-            double rate = exchangeRateService.getExchangeRate(sourceCurrency, targetCurrency);
+            final var rate = exchangeRateService.getExchangeRate(sourceCurrency, targetCurrency);
             logger.debug("Exchange rate from {} to {} is {}", sourceCurrency, targetCurrency, rate);
+            final var convertedAmount = amount.multiply(rate).setScale(2, RoundingMode.HALF_UP);
             CurrencyConversion conversion = CurrencyConversion.builder()
-                    .convertedAmount(amount * rate)
+                    .convertedAmount(convertedAmount)
                     .createdAt(LocalDate.now())
                     .build();
             CurrencyConversion savedConversion = repository.save(conversion);

--- a/src/main/java/com/openpayd/exchange/service/ExchangeRateService.java
+++ b/src/main/java/com/openpayd/exchange/service/ExchangeRateService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -33,7 +35,7 @@ public class ExchangeRateService {
     private String apiKey;
 
     @Cacheable(value = "exchangeRates", key = "#sourceCurrency + '-' + #targetCurrency", unless="#result == null")
-    public double getExchangeRate(String sourceCurrency, String targetCurrency) throws Exception {
+    public BigDecimal getExchangeRate(String sourceCurrency, String targetCurrency) throws Exception {
 
         logger.debug("Fetching exchange rate from {} to {}", sourceCurrency, targetCurrency);
         String route = String.format("https://api.currencyapi.com/v3/latest?apikey=%s&base_currency=%s&currencies=%s", apiKey, sourceCurrency, targetCurrency);
@@ -51,7 +53,7 @@ public class ExchangeRateService {
                 throw new CurrencyNotFoundException(ErrorCode.CURRENCY_NOT_FOUND);
             }
             JsonObject targetData = data.getAsJsonObject(targetCurrency);
-            var rate = targetData.get("value").getAsDouble();
+            var rate = targetData.get("value").getAsBigDecimal().setScale(2, RoundingMode.HALF_UP);
             logger.debug("Fetched exchange rate from {} to {}: {}", sourceCurrency, targetCurrency, rate);
             return rate;
 

--- a/src/test/java/com/openpayd/exchange/controller/ConversionHistoryControllerTest.java
+++ b/src/test/java/com/openpayd/exchange/controller/ConversionHistoryControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.UUID;
@@ -30,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ConversionHistoryController.class)
 class ConversionHistoryControllerTest {
 
-    private static final double CONVERTED_AMOUNT = 85.0;
+    private static final BigDecimal CONVERTED_AMOUNT = BigDecimal.valueOf(85.0);
 
     private static final LocalDate TRANSACTION_DATE = LocalDate.of(2024, 5, 5);
 

--- a/src/test/java/com/openpayd/exchange/controller/ExchangeRateControllerTest.java
+++ b/src/test/java/com/openpayd/exchange/controller/ExchangeRateControllerTest.java
@@ -3,6 +3,7 @@ package com.openpayd.exchange.controller;
 import com.openpayd.exchange.exception.CurrencyNotFoundException;
 import com.openpayd.exchange.exception.ErrorCode;
 import com.openpayd.exchange.service.ExchangeRateService;
+import constants.TestConstants;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -33,11 +36,11 @@ class ExchangeRateControllerTest {
 
     @Test
     void testGetExchangeRate() throws Exception {
-        Mockito.when(exchangeRateService.getExchangeRate("USD", "EUR")).thenReturn(0.85);
+        Mockito.when(exchangeRateService.getExchangeRate(TestConstants.USD, TestConstants.EUR)).thenReturn(BigDecimal.valueOf(0.85));
 
         var result = mockMvc.perform(get("/v1/exchange-rate")
-                        .param("sourceCurrency", "USD")
-                        .param("targetCurrency", "EUR"))
+                        .param("sourceCurrency", TestConstants.USD)
+                        .param("targetCurrency", TestConstants.EUR))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -51,12 +54,12 @@ class ExchangeRateControllerTest {
 
         String cacheKey = "USD-EUR";
 
-        Mockito.when(exchangeRateService.getExchangeRate("USD", "EUR")).thenReturn(0.85);
+        Mockito.when(exchangeRateService.getExchangeRate(TestConstants.USD, TestConstants.EUR)).thenReturn(BigDecimal.valueOf(0.85));
 
         // First request
         var result1 = mockMvc.perform(get("/v1/exchange-rate")
-                        .param("sourceCurrency", "USD")
-                        .param("targetCurrency", "EUR"))
+                        .param("sourceCurrency", TestConstants.USD)
+                        .param("targetCurrency", TestConstants.EUR))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -65,8 +68,8 @@ class ExchangeRateControllerTest {
 
         // Second request to test caching
         var result2 = mockMvc.perform(get("/v1/exchange-rate")
-                        .param("sourceCurrency", "USD")
-                        .param("targetCurrency", "EUR"))
+                        .param("sourceCurrency", TestConstants.USD)
+                        .param("targetCurrency", TestConstants.EUR))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn();
@@ -74,7 +77,7 @@ class ExchangeRateControllerTest {
         Assertions.assertEquals("0.85", result2.getResponse().getContentAsString());
 
         // Verify that the service method was called only once due to caching
-        verify(exchangeRateService, times(1)).getExchangeRate("USD", "EUR");
+        verify(exchangeRateService, times(1)).getExchangeRate(TestConstants.USD, TestConstants.EUR);
     }
 
     @Test
@@ -83,8 +86,8 @@ class ExchangeRateControllerTest {
                 .thenThrow(new CurrencyNotFoundException(ErrorCode.CURRENCY_NOT_FOUND));
 
         mockMvc.perform(get("/v1/exchange-rate")
-                        .param("sourceCurrency", "USD")
-                        .param("targetCurrency", "INVALID"))
+                        .param("sourceCurrency", TestConstants.USD)
+                        .param("targetCurrency", TestConstants.INVALID))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value(ErrorCode.CURRENCY_NOT_FOUND.getMessage()))

--- a/src/test/java/com/openpayd/exchange/service/ConversionHistoryServiceTest.java
+++ b/src/test/java/com/openpayd/exchange/service/ConversionHistoryServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +27,8 @@ import static org.mockito.Mockito.when;
 @SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class ConversionHistoryServiceTest {
+
+    private static final BigDecimal CONVERTED_AMOUNT = BigDecimal.valueOf(85.0);
 
     @Mock
     private CurrencyConversionRepository repository;
@@ -43,7 +46,7 @@ class ConversionHistoryServiceTest {
         UUID transactionId = UUID.randomUUID();
         CurrencyConversion conversion = CurrencyConversion.builder()
                 .id(transactionId)
-                .convertedAmount(85)
+                .convertedAmount(CONVERTED_AMOUNT)
                 .createdAt(LocalDate.now())
                 .build();
 
@@ -63,7 +66,7 @@ class ConversionHistoryServiceTest {
         LocalDate transactionDate = LocalDate.now().minusDays(1);
         CurrencyConversion conversion = CurrencyConversion.builder()
                 .id(UUID.randomUUID())
-                .convertedAmount(85)
+                .convertedAmount(CONVERTED_AMOUNT)
                 .createdAt(LocalDate.now())
                 .build();
 

--- a/src/test/java/constants/TestConstants.java
+++ b/src/test/java/constants/TestConstants.java
@@ -1,0 +1,12 @@
+package constants;
+
+/**
+ * @author suleyman.yildirim
+ */
+public final class TestConstants {
+    public static final String TRY = "TRY";
+    public static final String USD = "USD";
+    public static final String EUR = "EUR";
+    public static final String INVALID = "INVALID";
+    public static final String EMPTY_CURRENCY = "";
+}


### PR DESCRIPTION
-  Convert double to BigDecimal for precision and ability to handle large numbers without losing accuracy.
-  Use RoundingMode.HALF_UP to ensure that currency conversions are consistent with industry standards.